### PR TITLE
add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+---
+Language: Cpp
+AccessModifierOffset: -2
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+# BreakBeforeBraces: Mozilla
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+# ColumnLimit: 100
+DerivePointerAlignment: false
+DisableFormat: false
+PointerAlignment: Right
+SortIncludes: true
+UseTab: Never

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,13 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.10.2
+      with:
+        clang-format-version: '15'
+        fallback-style: 'Google' # optional

--- a/FlowCV_SDK/third-party/.clang-format
+++ b/FlowCV_SDK/third-party/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/Plugins/DataOutput/macos/serial/.clang-format
+++ b/Plugins/DataOutput/macos/serial/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/Plugins/DataOutput/win/List_Serial_Ports_Win.hpp
+++ b/Plugins/DataOutput/win/List_Serial_Ports_Win.hpp
@@ -6,6 +6,7 @@
 #ifndef FLOWCV_SERIAL_PORTS_WIN_HPP_
 #define FLOWCV_SERIAL_PORTS_WIN_HPP_
 
+// clang-format off
 #include <iostream>
 #include <string>
 #include <tchar.h>
@@ -14,6 +15,7 @@
 #include <setupapi.h>
 #include <initguid.h>
 #include <devguid.h>
+// clang-format on
 
 namespace SerialDeviceEnum {
 

--- a/third-party/.clang-format
+++ b/third-party/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false


### PR DESCRIPTION
Hi @rwardlow01 , do you mind using .clang-format for code formatting?

In my opinion, automatic code formatting is very necessary for the collaborative development of the project. However, adding formatting will also bring a lot of file changes, but I think it is acceptable.

I submitted a formatted document based on Google style in this PR. Of course, I have made some modifications to the format used in the current project, such as 
```yaml
IndentWidth: 4
PointerAlignment: Right
```

We can also choose not to enable automatic sorting of include.

```yaml
SortIncludes: false 
```

If you feel any dissatisfaction or what else can be adjusted, we can communicate and modify it.

Thank you.

[https://clang.llvm.org/docs/ClangFormatStyleOptions.html](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)