### PR TITLE
[cmake] Modify file output and opencv download method

### DIFF
--- a/CMake/ImGuiOpenCvConfig.cmake
+++ b/CMake/ImGuiOpenCvConfig.cmake
@@ -1,7 +1,17 @@
 # OpenCV Configuration
 message(STATUS "Adding ImGUI OpenCV CMake Config")
 
-if ((NOT USE_LOCAL_OPENCV_PACKAGE))
+if (USE_LOCAL_OPENCV_PACKAGE)
+    find_package(OpenCV)
+    if(OpenCV_FOUND)
+        message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
+    else()
+        message(WARNING "Opencv Package NOT Found")
+        set(USE_LOCAL_OPENCV_PACKAGE OFF)
+    endif()
+endif()
+
+if (NOT USE_LOCAL_OPENCV_PACKAGE)
     if (WIN32)
         if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             message(FATAL_ERROR "Only 64-bit supported on Windows")
@@ -39,25 +49,14 @@ if ((NOT USE_LOCAL_OPENCV_PACKAGE))
         set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
         find_package(OpenCV REQUIRED PATHS ${OpenCV_DIR})
 
-        # file(GLOB files "${OpenCV_DIR}/../bin/*.dll")
-        # foreach(file_cv ${files})
-        #     file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
-        # endforeach()
+        file(GLOB files "${OpenCV_DIR}/../bin/*.dll")
+        foreach(file_cv ${files})
+            file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+        endforeach()
     else()
         message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
     endif()
-
-else()
-    find_package(OpenCV)
 endif()
-
-if(OpenCV_FOUND)
-    message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
-else()
-    message(FATAL_ERROR "Opencv Package NOT Found")
-endif()
-
-# include_directories(${OpenCV_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11
 
 set(IMGUI_OPENCV_DIR ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/imgui_wrapper)
 list(APPEND IMGUI_OPENCV_SRC "${IMGUI_OPENCV_DIR}/imgui_opencv.cpp")

--- a/CMake/ImGuiOpenCvConfig.cmake
+++ b/CMake/ImGuiOpenCvConfig.cmake
@@ -1,50 +1,63 @@
 # OpenCV Configuration
-if (WIN32)
-    if (NOT OpenCV_DIR)
-        set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
-    endif()
-endif()
-
 message(STATUS "Adding ImGUI OpenCV CMake Config")
 
-FIND_PACKAGE( OpenCV )
-
-if (NOT OPENCV_CORE_FOUND)
-    message(WARNING "OpenCV Not Found")
-    if (DOWNLOAD_OPENCV_PACKAGE)
-        message(STATUS "Downloading OpenCV Package")
-        if (WIN32)
-            if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-                message(FATAL_ERROR "Only 64-bit supported on Windows")
-            endif()
-            if (CMAKE_BUILD_TYPE STREQUAL "Release")
-                file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.zip "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv_4.5.5.zip")
-                message(STATUS "Download Complete")
-                message(STATUS "Extracting Files...")
-                file(ARCHIVE_EXTRACT INPUT "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv_4.5.5.zip" DESTINATION "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/")
-                message(STATUS "Files Extracted")
-                message(STATUS "Removing Archive")
-                file(REMOVE "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv_4.5.5.zip")
-                message(STATUS "Sourcing Package")
-                set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
-            endif()
-            FIND_PACKAGE( OpenCV REQUIRED PATHS ${OpenCV_DIR})
-        else()
-            message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
-        endif()
-    endif()
-endif()
-
-if (OPENCV_CORE_FOUND)
+if ((NOT USE_LOCAL_OPENCV_PACKAGE))
     if (WIN32)
-        file(GLOB files "${OpenCV_DIR}/../bin/*.*")
-        foreach(file_cv ${files})
-            file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
-        endforeach()
+        if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            message(FATAL_ERROR "Only 64-bit supported on Windows")
+        endif()
+
+        set(OPENCV_FILE_NAME_DEBUG "opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2-debug.7z")
+        set(OPENCV_FILE_NAME_RELEASE "opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z")
+
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv*")
+            # Download OpenCV
+            if ((DEFINED CMAKE_BUILD_TYPE) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+                message(WARNING "See https://github.com/FlowCV-org/FlowCV/issues/8")
+            elseif(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/lib/opencv_core455.lib")
+                message(STATUS "Downloading OpenCV Package (Release)")
+                file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z 
+                    "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}"
+                    EXPECTED_HASH SHA256=f76c83db33815ce27144c6b20ed37e8f0b4ae199ad9b3a0291ccfcf7b0fb2703
+                )
+                message(STATUS "Download Complete")
+            else()
+                message(STATUS "OpenCV Package Already Exists In ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
+            endif()
+        endif()
+
+        # Extract OpenCV
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
+            message(STATUS "Extracting Files...")
+            file(ARCHIVE_EXTRACT INPUT "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}" DESTINATION "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/")
+            message(STATUS "Files Extracted")
+            message(STATUS "Removing Archive")
+            file(REMOVE "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}")
+        endif()
+
+        # Set OpenCV_DIR
+        set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
+        find_package(OpenCV REQUIRED PATHS ${OpenCV_DIR})
+
+        # file(GLOB files "${OpenCV_DIR}/../bin/*.dll")
+        # foreach(file_cv ${files})
+        #     file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+        # endforeach()
+    else()
+        message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
     endif()
+
+else()
+    find_package(OpenCV)
 endif()
 
-INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
+if(OpenCV_FOUND)
+    message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
+else()
+    message(FATAL_ERROR "Opencv Package NOT Found")
+endif()
+
+# include_directories(${OpenCV_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11
 
 set(IMGUI_OPENCV_DIR ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/imgui_wrapper)
 list(APPEND IMGUI_OPENCV_SRC "${IMGUI_OPENCV_DIR}/imgui_opencv.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,16 @@ project(OpenCV_Dataflow_Framework)
 set(CMAKE_CXX_STANDARD 17)
 
 # Options
-option(DOWNLOAD_OPENCV_PACKAGE "Download OpenCV Package" ON)
-option(BUILD_EXAMPLES "Build Examples" OFF)
-option(BUILD_PLUGINS "Build Plugins" OFF)
-option(BUILD_EDITOR "Build Editor" OFF)
-option(BUILD_ENGINE "Build Engine" OFF)
+option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
+option(BUILD_EXAMPLES "Build Examples" ON)
+option(BUILD_PLUGINS "Build Plugins" ON)
+option(BUILD_EDITOR "Build Editor" ON)
+option(BUILD_ENGINE "Build Engine" ON)
+
+set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_RELEASE_POSTFIX "")
+set(CMAKE_RELWITHDEBINFO_POSTFIX "rd")
+set(CMAKE_MINSIZEREL_POSTFIX "s")
 
 # Include all modules by default, modify based on your project needs
 include(${CMAKE_SOURCE_DIR}/CMake/ImGuiOpenCvConfig.cmake)
@@ -35,8 +40,6 @@ if (BUILD_PLUGINS)
     add_subdirectory(./Plugins/SimpleBlobTracker)
     add_subdirectory(./Plugins/DataOutput)
     add_subdirectory(./Plugins/ImageWriter)
-
-
 endif()
 
 if (BUILD_ENGINE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,15 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 
+# When compiling with Release, the console window is not generated
+if(WIN32)
+  if(MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
+  else()
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mwindows")
+  endif(MSVC)
+endif(WIN32)
+
 # Options
 option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
 option(BUILD_EXAMPLES "Build Examples" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,24 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 
-# When compiling with Release, the console window is not generated
-if(WIN32)
-  if(MSVC)
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
-  else()
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mwindows")
-  endif(MSVC)
-endif(WIN32)
-
 # Options
 option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
+option(USE_LOG_WINDOW "Use the command line window to display the log" ON)
 option(BUILD_EXAMPLES "Build Examples" ON)
 option(BUILD_PLUGINS "Build Plugins" ON)
 option(BUILD_EDITOR "Build Editor" ON)
 option(BUILD_ENGINE "Build Engine" ON)
+
+if(NOT USE_LOG_WINDOW)
+  # When compiling with Release, the console window is not generated
+  if(WIN32)
+    if(MSVC)
+      set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
+    else()
+      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mwindows")
+    endif(MSVC)
+  endif(WIN32)
+endif()
 
 # Set Output Path
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
-project(OpenCV_Dataflow_Framework)
+
+cmake_policy(SET CMP0068 NEW) # new in 3.9. The NEW behavior of this policy is to ignore the RPATH settings for install_name on macOS.
+
+project(OpenCV_Dataflow_Framework LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 
 # Options
 option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
@@ -9,6 +14,24 @@ option(BUILD_EXAMPLES "Build Examples" ON)
 option(BUILD_PLUGINS "Build Plugins" ON)
 option(BUILD_EDITOR "Build Editor" ON)
 option(BUILD_ENGINE "Build Engine" ON)
+
+# Set Output Path
+include(GNUInstallDirs)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+
+if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE})
+endif()
+
+foreach(OUTPUT_TYPES ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${OUTPUT_TYPES} OUTPUT_CONFIG)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${OUTPUT_TYPES})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${OUTPUT_TYPES})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${OUTPUT_TYPES})
+    message(STATUS "CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} : ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG}}")
+endforeach(OUTPUT_TYPES CMAKE_CONFIGURATION_TYPES)
 
 set(CMAKE_DEBUG_POSTFIX "d")
 set(CMAKE_RELEASE_POSTFIX "")
@@ -29,30 +52,22 @@ include(${CMAKE_SOURCE_DIR}/CMake/FlowCVConfig.cmake)
 # JSON
 include_directories(${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/nlohmann)
 
-if (BUILD_PLUGINS)
+if(BUILD_PLUGINS)
     # FlowCV Plugin Modules
-    add_subdirectory(./Plugins/VideoCapture)
-    add_subdirectory(./Plugins/VideoWriter)
-    add_subdirectory(./Plugins/ImageLoader)
-    add_subdirectory(./Plugins/VideoLoader)
-    add_subdirectory(./Plugins/ShapeColorizer)
-    add_subdirectory(./Plugins/ShapeCounter)
-    add_subdirectory(./Plugins/SimpleBlobTracker)
-    add_subdirectory(./Plugins/DataOutput)
-    add_subdirectory(./Plugins/ImageWriter)
+    add_subdirectory(Plugins)
 endif()
 
-if (BUILD_ENGINE)
+if(BUILD_ENGINE)
     # OpenCV DSPatch Standalone Processing Engine
     add_subdirectory(Processing_Engine)
 endif()
 
-if (BUILD_EDITOR)
+if(BUILD_EDITOR)
     # OpenCV DSPatch Node Editor UI
     add_subdirectory(Editor_UI)
 endif()
 
-if (BUILD_EXAMPLES)
+if(BUILD_EXAMPLES)
     # Build Examples
     add_subdirectory(Examples/FlowCV_Dataflow_Test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 project(OpenCV_Dataflow_Framework)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/Editor_UI/CMakeLists.txt
+++ b/Editor_UI/CMakeLists.txt
@@ -46,24 +46,3 @@ else()
             pthread
             )
 endif()
-
-if(WIN32)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_RPATH "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_NAME_DIR "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()

--- a/Examples/FlowCV_Dataflow_Test/CMakeLists.txt
+++ b/Examples/FlowCV_Dataflow_Test/CMakeLists.txt
@@ -34,24 +34,3 @@ else()
             pthread
             )
 endif()
-
-if(WIN32)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_RPATH ${ORIGIN};./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_NAME_DIR ${ORIGIN};./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()

--- a/FlowCV_SDK/CMake/OpenCvConfig.cmake
+++ b/FlowCV_SDK/CMake/OpenCvConfig.cmake
@@ -1,48 +1,60 @@
 # OpenCV Configuration
-if (WIN32)
-    if (NOT OpenCV_DIR)
-        set(OpenCV_DIR "${FLOWCV_PROJ_DIR}/third-party/opencv/build/cmake")
-    endif()
-endif()
-
 message(STATUS "Adding OpenCV CMake Config")
 
-FIND_PACKAGE( OpenCV )
+if ((NOT USE_LOCAL_OPENCV_PACKAGE))
+    if (WIN32)
+        if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            message(FATAL_ERROR "Only 64-bit supported on Windows")
+        endif()
 
-if (NOT OPENCV_CORE_FOUND)
-    message(WARNING "OpenCV Not Found")
-    if (DOWNLOAD_OPENCV_PACKAGE)
-        message(STATUS "Downloading OpenCV Package")
-        if (WIN32)
-            if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-                message(FATAL_ERROR "Only 64-bit supported on Windows")
+        set(OPENCV_FILE_NAME_DEBUG "opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2-debug.7z")
+        set(OPENCV_FILE_NAME_RELEASE "opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z")
+
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv*")
+            # Download OpenCV
+            if ((DEFINED CMAKE_BUILD_TYPE) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+                message(WARNING "See https://github.com/FlowCV-org/FlowCV/issues/8")
+            elseif(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/lib/opencv_core455.lib")
+                message(STATUS "Downloading OpenCV Package (Release)")
+                file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z 
+                    "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}"
+                    EXPECTED_HASH SHA256=f76c83db33815ce27144c6b20ed37e8f0b4ae199ad9b3a0291ccfcf7b0fb2703
+                )
+                message(STATUS "Download Complete")
+            else()
+                message(STATUS "OpenCV Package Already Exists In ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
             endif()
-            file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.zip "${FLOWCV_PROJ_DIR}/third-party/opencv_4.5.5.zip")
-            message(STATUS "Download Complete")
+        endif()
+
+        # Extract OpenCV
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
             message(STATUS "Extracting Files...")
-            file(ARCHIVE_EXTRACT INPUT "${FLOWCV_PROJ_DIR}/third-party/opencv_4.5.5.zip" DESTINATION "${FLOWCV_PROJ_DIR}/third-party/")
+            file(ARCHIVE_EXTRACT INPUT "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}" DESTINATION "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/")
             message(STATUS "Files Extracted")
             message(STATUS "Removing Archive")
-            file(REMOVE "${FLOWCV_PROJ_DIR}/third-party/opencv_4.5.5.zip")
-            message(STATUS "Sourcing Package")
-            set(OpenCV_DIR "${FLOWCV_PROJ_DIR}/third-party/opencv/build/cmake")
-            FIND_PACKAGE( OpenCV REQUIRED PATHS ${OpenCV_DIR})
-        #if(APPLE)
-
-        else()
-            message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
+            file(REMOVE "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}")
         endif()
+
+        # Set OpenCV_DIR
+        set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
+        find_package(OpenCV REQUIRED PATHS ${OpenCV_DIR})
+
+        # file(GLOB files "${OpenCV_DIR}/../bin/*.dll")
+        # foreach(file_cv ${files})
+        #     file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+        # endforeach()
+    else()
+        message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
     endif()
+
+else()
+    find_package(OpenCV)
 endif()
 
-if (OPENCV_CORE_FOUND)
-    if (WIN32)
-        file(GLOB files "${OpenCV_DIR}/../bin/*.*")
-        foreach(file_cv ${files})
-            file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
-        endforeach()
-    endif()
+if(OpenCV_FOUND)
+    message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
+else()
+    message(FATAL_ERROR "Opencv Package NOT Found")
 endif()
 
-INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
-
+# include_directories(${OpenCV_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11

--- a/FlowCV_SDK/CMake/OpenCvConfig.cmake
+++ b/FlowCV_SDK/CMake/OpenCvConfig.cmake
@@ -1,7 +1,17 @@
 # OpenCV Configuration
 message(STATUS "Adding OpenCV CMake Config")
 
-if ((NOT USE_LOCAL_OPENCV_PACKAGE))
+if (USE_LOCAL_OPENCV_PACKAGE)
+    find_package(OpenCV)
+    if(OpenCV_FOUND)
+        message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
+    else()
+        message(WARNING "Opencv Package NOT Found")
+        set(USE_LOCAL_OPENCV_PACKAGE OFF)
+    endif()
+endif()
+
+if (NOT USE_LOCAL_OPENCV_PACKAGE)
     if (WIN32)
         if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             message(FATAL_ERROR "Only 64-bit supported on Windows")
@@ -46,15 +56,4 @@ if ((NOT USE_LOCAL_OPENCV_PACKAGE))
     else()
         message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
     endif()
-
-else()
-    find_package(OpenCV)
 endif()
-
-if(OpenCV_FOUND)
-    message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
-else()
-    message(FATAL_ERROR "Opencv Package NOT Found")
-endif()
-
-# include_directories(${OpenCV_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11

--- a/FlowCV_SDK/FlowCVConfig.cmake
+++ b/FlowCV_SDK/FlowCVConfig.cmake
@@ -10,7 +10,7 @@ set(FLOWCV_VERSION_STATUS "")
 
 set(FLOWCV_PROJ_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-option(DOWNLOAD_OPENCV_PACKAGE "Download OpenCV Package" ON)
+option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
 
 include(${FLOWCV_PROJ_DIR}/CMake/ImGuiConfig.cmake)
 include(${FLOWCV_PROJ_DIR}/CMake/FlowCVConfig.cmake)

--- a/Plugins/CMakeLists.txt
+++ b/Plugins/CMakeLists.txt
@@ -1,0 +1,67 @@
+# 获取目录下的子目录名
+# subdirnamelist 子目录名称列表，输出变量，调用处定义，填充时不能加${}
+# targetdir      目标路径，为全路径
+macro(SUBDIRNAMELIST_MACRO subdirnamelist targetdir)
+    # message(STATUS "macro subdirnamelist = ${subdirnamelist}")
+    # message(STATUS "macro targetdir = ${targetdir}")
+    file(GLOB children ${targetdir}/*) # 获取目标路径下的内容，深度为1
+    # message(STATUS "macro children = ${children}")
+    set(dirlist "")
+    foreach(child ${children})
+        file(RELATIVE_PATH child_name ${targetdir} ${child}) # 通过相对路径计算获取名称
+        # message(STATUS "macro child = ${child_name}")
+        # message(STATUS "targetdir/child = ${targetdir}/${child_name}")
+        if(IS_DIRECTORY ${targetdir}/${child_name})
+            # message(STATUS "yes dir : targetdir/child = ${targetdir}/${child_name}")
+            list(APPEND dirlist ${child_name})
+        endif()
+    endforeach()
+    list(APPEND ${subdirnamelist} ${dirlist})
+    # message(STATUS "macro dirlist = ${dirlist}")
+    # message(STATUS "macro subdirnamelist = ${subdirnamelist}")
+endmacro()
+ 
+# 获取目录下是否有CMakeLists
+# hascmakelist 是否含有CMakeLists.txt，输出变量，调用处定义，填充时不能加${}
+# targetdir    目标路径，为全路径
+macro(CHECK_DIR_HAS_CMAKELIST hascmakelist targetdir)
+    # message(STATUS "macro check has cmakelist targetdir = ${targetdir}")
+    set(${hascmakelist} FALSE)
+    if(IS_DIRECTORY ${targetdir})
+        # message(STATUS "macro check has cmakelist is dir, targetdir = ${targetdir}")
+        if(EXISTS ${targetdir}/CMakeLists.txt)
+            set(${hascmakelist} TRUE)
+        endif()
+    else()
+        message(FATAL_ERROR "Invalid dir para: targetdir = ${targetdir}")
+    endif()
+endmacro()
+ 
+# 为含有CMakeList的子目录添加add_subdirectory调用
+# 自动识别调用处所在目录有哪些子目录，并为还有CMakeLists.txt的子目录添加add_sundirectory调用
+macro(add_all_subdirectory)
+    set(subdirnamelisttemp "")
+    SUBDIRNAMELIST_MACRO(subdirnamelisttemp ${CMAKE_CURRENT_SOURCE_DIR})
+    # message(STATUS "[macro add_all_subdirectory] subdirnamelisttemp = ${subdirnamelisttemp}")
+    foreach(subdir ${subdirnamelisttemp})
+        # message(STATUS "[macro add_all_subdirectory] subdir = ${subdir}")
+        set(hascmakelisttemp FALSE)
+        CHECK_DIR_HAS_CMAKELIST(hascmakelisttemp ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
+        # message(STATUS "[macro add_all_subdirectory] hascmakelisttemp = ${hascmakelisttemp}")
+        if(${hascmakelisttemp})
+            message(STATUS "[macro add_all_subdirectory] add_subdirectory(${subdir})")
+            add_subdirectory(${subdir})
+        endif()
+    endforeach()
+endmacro()
+
+
+foreach(OUTPUT_TYPES ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${OUTPUT_TYPES} OUTPUT_CONFIG)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUT_CONFIG}}/Plugins)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUT_CONFIG}}/Plugins)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG}}/Plugins)
+    # message(STATUS "CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG} : ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUT_CONFIG}}")
+endforeach(OUTPUT_TYPES CMAKE_CONFIGURATION_TYPES)
+
+add_all_subdirectory()

--- a/Plugins/DataOutput/CMakeLists.txt
+++ b/Plugins/DataOutput/CMakeLists.txt
@@ -48,29 +48,10 @@ target_link_libraries(
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
 )
-if(WIN32)
 set_target_properties(UdpSend
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
         SUFFIX ".fp"
         )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(UdpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(UdpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
 
 # TCP Send
 add_library(
@@ -87,29 +68,10 @@ target_link_libraries(
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
 )
-if(WIN32)
 set_target_properties(TcpSend
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
         SUFFIX ".fp"
         )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(TcpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(TcpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
 
 # Serial Send
 add_library(
@@ -140,29 +102,10 @@ target_link_libraries(
         ${SER_ENUM_LIB}
 )
 endif()
-if(WIN32)
 set_target_properties(SerialSend
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
         SUFFIX ".fp"
         )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(SerialSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(SerialSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
 
 # OSC Send
 add_library(
@@ -180,29 +123,10 @@ target_link_libraries(
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
 )
-if(WIN32)
 set_target_properties(OscSend
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
         SUFFIX ".fp"
         )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(OscSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(OscSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
 
 # CSV File
 add_library(
@@ -219,26 +143,7 @@ target_link_libraries(
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
 )
-if(WIN32)
 set_target_properties(CsvFile
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
         SUFFIX ".fp"
         )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(CsvFile
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(CsvFile
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()

--- a/Plugins/ImageLoader/CMakeLists.txt
+++ b/Plugins/ImageLoader/CMakeLists.txt
@@ -16,26 +16,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/ImageWriter/CMakeLists.txt
+++ b/Plugins/ImageWriter/CMakeLists.txt
@@ -16,26 +16,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/ShapeColorizer/CMakeLists.txt
+++ b/Plugins/ShapeColorizer/CMakeLists.txt
@@ -16,26 +16,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/ShapeCounter/CMakeLists.txt
+++ b/Plugins/ShapeCounter/CMakeLists.txt
@@ -16,26 +16,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/SimpleBlobTracker/CMakeLists.txt
+++ b/Plugins/SimpleBlobTracker/CMakeLists.txt
@@ -16,26 +16,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/VideoCapture/CMakeLists.txt
+++ b/Plugins/VideoCapture/CMakeLists.txt
@@ -35,27 +35,4 @@ target_link_libraries(
         ${SYS_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
-
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/VideoLoader/CMakeLists.txt
+++ b/Plugins/VideoLoader/CMakeLists.txt
@@ -17,26 +17,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Plugins/VideoWriter/CMakeLists.txt
+++ b/Plugins/VideoWriter/CMakeLists.txt
@@ -16,26 +16,4 @@ target_link_libraries(
         ${OpenCV_LIBS}
 )
 
-if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-        SUFFIX ".fp"
-        )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".fp")

--- a/Processing_Engine/CMakeLists.txt
+++ b/Processing_Engine/CMakeLists.txt
@@ -37,24 +37,3 @@ else()
             pthread
             )
 endif()
-
-if(WIN32)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            )
-elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_RPATH "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
-elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_NAME_DIR "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
-endif()

--- a/Templates/Plugin/CMakeLists.txt
+++ b/Templates/Plugin/CMakeLists.txt
@@ -18,6 +18,5 @@ target_link_libraries(
 
 set_target_properties(${PROJECT_NAME}
         PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
         SUFFIX ".fp"
         )


### PR DESCRIPTION
* Modify the download method of opencv in cmake
Use the variable `USE_LOCAL_OPENCV_PACKAGE` to decide whether to download opencv, and add a sha256 checksum
* Modify output path
Has consistent output on both windows and ubuntu.
```
├─bin
│  ├─Debug
│  │  └─Plugins
│  ├─Release
│  │  └─Plugins
│  └─RelWithDebInfo
│      └─Plugins
├─lib
│  ├─Debug
│  │  └─Plugins
│  ├─Release
│  │  └─Plugins
│  └─RelWithDebInfo
│      └─Plugins
```
* Set cmake minimum version to 3.16
No problem on windows and ubuntu

* Compile with Release, remove the console window, in the windows environment

Sorry, I don't have a maxos environment.

It may be a big change, but I've separated them into different commits @rwardlow01 