### PR TITLE
Set the BUILD option to ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ set(CMAKE_CXX_STANDARD 17)
 # Options
 option(DOWNLOAD_OPENCV_PACKAGE "Download OpenCV Package" ON)
 option(BUILD_EXAMPLES "Build Examples" OFF)
-option(BUILD_PLUGINS "Build Plugins" OFF)
-option(BUILD_EDITOR "Build Editor" OFF)
-option(BUILD_ENGINE "Build Engine" OFF)
+option(BUILD_PLUGINS "Build Plugins" ON)
+option(BUILD_EDITOR "Build Editor" ON)
+option(BUILD_ENGINE "Build Engine" ON)
 
 # Include all modules by default, modify based on your project needs
 include(${CMAKE_SOURCE_DIR}/CMake/ImGuiOpenCvConfig.cmake)


### PR DESCRIPTION
I may not understand why these options are set to OFF.

After I run it the first time, I don't get any executables.

I think at least BUILD_EDITOR needs to be set to ON. What do you think?