### PR TITLE
Modify opencv config cmake

### DIFF
--- a/CMake/ImGuiOpenCvConfig.cmake
+++ b/CMake/ImGuiOpenCvConfig.cmake
@@ -1,50 +1,62 @@
 # OpenCV Configuration
-if (WIN32)
-    if (NOT OpenCV_DIR)
-        set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
-    endif()
-endif()
-
 message(STATUS "Adding ImGUI OpenCV CMake Config")
 
-FIND_PACKAGE( OpenCV )
-
-if (NOT OPENCV_CORE_FOUND)
-    message(WARNING "OpenCV Not Found")
-    if (DOWNLOAD_OPENCV_PACKAGE)
-        message(STATUS "Downloading OpenCV Package")
-        if (WIN32)
-            if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-                message(FATAL_ERROR "Only 64-bit supported on Windows")
-            endif()
-            if (CMAKE_BUILD_TYPE STREQUAL "Release")
-                file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.zip "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv_4.5.5.zip")
-                message(STATUS "Download Complete")
-                message(STATUS "Extracting Files...")
-                file(ARCHIVE_EXTRACT INPUT "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv_4.5.5.zip" DESTINATION "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/")
-                message(STATUS "Files Extracted")
-                message(STATUS "Removing Archive")
-                file(REMOVE "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv_4.5.5.zip")
-                message(STATUS "Sourcing Package")
-                set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
-            endif()
-            FIND_PACKAGE( OpenCV REQUIRED PATHS ${OpenCV_DIR})
-        else()
-            message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
-        endif()
+if (USE_LOCAL_OPENCV_PACKAGE)
+    find_package(OpenCV)
+    if(OpenCV_FOUND)
+        message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
+    else()
+        message(WARNING "OpenCV Package NOT Found, download it")
+        set(USE_LOCAL_OPENCV_PACKAGE OFF)
     endif()
 endif()
 
-if (OPENCV_CORE_FOUND)
+if (NOT USE_LOCAL_OPENCV_PACKAGE)
     if (WIN32)
-        file(GLOB files "${OpenCV_DIR}/../bin/*.*")
+        if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            message(FATAL_ERROR "Only 64-bit supported on Windows")
+        endif()
+
+        set(OPENCV_FILE_NAME_RELEASE "opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z")
+
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv*")
+            # Download OpenCV
+            if ((DEFINED CMAKE_BUILD_TYPE) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+                message(WARNING "See https://github.com/FlowCV-org/FlowCV/issues/8")
+            elseif(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/lib/opencv_core455.lib")
+                message(STATUS "Downloading OpenCV Package (Release)")
+                file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z 
+                    "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}"
+                    EXPECTED_HASH SHA256=f76c83db33815ce27144c6b20ed37e8f0b4ae199ad9b3a0291ccfcf7b0fb2703
+                )
+                message(STATUS "Download Complete")
+            else()
+                message(STATUS "OpenCV Package Already Exists In ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
+            endif()
+        endif()
+
+        # Extract OpenCV
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
+            message(STATUS "Extracting Files...")
+            file(ARCHIVE_EXTRACT INPUT "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}" DESTINATION "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/")
+            message(STATUS "Files Extracted")
+            message(STATUS "Removing Archive")
+            file(REMOVE "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}")
+        endif()
+
+        # Set OpenCV_DIR
+        set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
+        find_package(OpenCV REQUIRED PATHS ${OpenCV_DIR})
+
+        # Copy OpenCV DLL
+        file(GLOB files "${OpenCV_DIR}/../bin/*.dll")
         foreach(file_cv ${files})
             file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
         endforeach()
+    else()
+        message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
     endif()
 endif()
-
-INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
 
 set(IMGUI_OPENCV_DIR ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/imgui_wrapper)
 list(APPEND IMGUI_OPENCV_SRC "${IMGUI_OPENCV_DIR}/imgui_opencv.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(OpenCV_Dataflow_Framework)
 set(CMAKE_CXX_STANDARD 17)
 
 # Options
-option(DOWNLOAD_OPENCV_PACKAGE "Download OpenCV Package" ON)
+option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
 option(BUILD_EXAMPLES "Build Examples" OFF)
 option(BUILD_PLUGINS "Build Plugins" ON)
 option(BUILD_EDITOR "Build Editor" ON)

--- a/FlowCV_SDK/CMake/OpenCvConfig.cmake
+++ b/FlowCV_SDK/CMake/OpenCvConfig.cmake
@@ -1,48 +1,59 @@
 # OpenCV Configuration
-if (WIN32)
-    if (NOT OpenCV_DIR)
-        set(OpenCV_DIR "${FLOWCV_PROJ_DIR}/third-party/opencv/build/cmake")
-    endif()
-endif()
-
 message(STATUS "Adding OpenCV CMake Config")
 
-FIND_PACKAGE( OpenCV )
-
-if (NOT OPENCV_CORE_FOUND)
-    message(WARNING "OpenCV Not Found")
-    if (DOWNLOAD_OPENCV_PACKAGE)
-        message(STATUS "Downloading OpenCV Package")
-        if (WIN32)
-            if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-                message(FATAL_ERROR "Only 64-bit supported on Windows")
-            endif()
-            file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.zip "${FLOWCV_PROJ_DIR}/third-party/opencv_4.5.5.zip")
-            message(STATUS "Download Complete")
-            message(STATUS "Extracting Files...")
-            file(ARCHIVE_EXTRACT INPUT "${FLOWCV_PROJ_DIR}/third-party/opencv_4.5.5.zip" DESTINATION "${FLOWCV_PROJ_DIR}/third-party/")
-            message(STATUS "Files Extracted")
-            message(STATUS "Removing Archive")
-            file(REMOVE "${FLOWCV_PROJ_DIR}/third-party/opencv_4.5.5.zip")
-            message(STATUS "Sourcing Package")
-            set(OpenCV_DIR "${FLOWCV_PROJ_DIR}/third-party/opencv/build/cmake")
-            FIND_PACKAGE( OpenCV REQUIRED PATHS ${OpenCV_DIR})
-        #if(APPLE)
-
-        else()
-            message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
-        endif()
+if (USE_LOCAL_OPENCV_PACKAGE)
+    find_package(OpenCV)
+    if(OpenCV_FOUND)
+        message(STATUS "OpenCV_VERSION: ${OpenCV_VERSION}, OpenCV_DIR: ${OpenCV_DIR}")
+    else()
+        message(WARNING "OpenCV Package NOT Found, download it")
+        set(USE_LOCAL_OPENCV_PACKAGE OFF)
     endif()
 endif()
 
-if (OPENCV_CORE_FOUND)
+if (NOT USE_LOCAL_OPENCV_PACKAGE)
     if (WIN32)
-        file(GLOB files "${OpenCV_DIR}/../bin/*.*")
+        if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            message(FATAL_ERROR "Only 64-bit supported on Windows")
+        endif()
+
+        set(OPENCV_FILE_NAME_RELEASE "opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z")
+
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv*")
+            # Download OpenCV
+            if ((DEFINED CMAKE_BUILD_TYPE) AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+                message(WARNING "See https://github.com/FlowCV-org/FlowCV/issues/8")
+            elseif(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/lib/opencv_core455.lib")
+                message(STATUS "Downloading OpenCV Package (Release)")
+                file(DOWNLOAD https://github.com/opencv/opencv/releases/download/4.5.5/opencv-4.5.5-openvino-dldt-2021.4.2-vc16-avx2.7z 
+                    "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}"
+                    EXPECTED_HASH SHA256=f76c83db33815ce27144c6b20ed37e8f0b4ae199ad9b3a0291ccfcf7b0fb2703
+                )
+                message(STATUS "Download Complete")
+            else()
+                message(STATUS "OpenCV Package Already Exists In ${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
+            endif()
+        endif()
+
+        # Extract OpenCV
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv")
+            message(STATUS "Extracting Files...")
+            file(ARCHIVE_EXTRACT INPUT "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}" DESTINATION "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/")
+            message(STATUS "Files Extracted")
+            message(STATUS "Removing Archive")
+            file(REMOVE "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/${OPENCV_FILE_NAME_RELEASE}")
+        endif()
+
+        # Set OpenCV_DIR
+        set(OpenCV_DIR "${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/opencv/build/cmake")
+        find_package(OpenCV REQUIRED PATHS ${OpenCV_DIR})
+
+        # Copy OpenCV DLL
+        file(GLOB files "${OpenCV_DIR}/../bin/*.dll")
         foreach(file_cv ${files})
             file(COPY "${file_cv}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
         endforeach()
+    else()
+        message(FATAL_ERROR "No OpenCV Detected Please Install OpenCV System Package")
     endif()
 endif()
-
-INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
-

--- a/FlowCV_SDK/FlowCVConfig.cmake
+++ b/FlowCV_SDK/FlowCVConfig.cmake
@@ -10,7 +10,7 @@ set(FLOWCV_VERSION_STATUS "")
 
 set(FLOWCV_PROJ_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-option(DOWNLOAD_OPENCV_PACKAGE "Download OpenCV Package" ON)
+option(USE_LOCAL_OPENCV_PACKAGE "Use locally OpenCV Package" ON)
 
 include(${FLOWCV_PROJ_DIR}/CMake/ImGuiConfig.cmake)
 include(${FLOWCV_PROJ_DIR}/CMake/FlowCVConfig.cmake)


### PR DESCRIPTION
If opencv exists locally, it is used locally, if not, it is automatically downloaded and used.
If the automatically downloaded opencv already exists, skip the download and use it.

OpenCV_DIR is added to the PATH. cmake automatically recognizes the local opencv and does not need to be configured in cmake.

![image](https://user-images.githubusercontent.com/55644167/232657394-663d53a8-8bc2-470b-9494-8d05441f3386.png)
