### PR TITLE
add logging tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ CTestTestfile.cmake
 _deps
 .vs/
 .vscode/
+.cache
 *.pdb
 *.vcxproj
 *.vcxproj.filters
@@ -25,3 +26,5 @@ _deps
 *.recipe
 x64/
 ?ebug/
+
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Docs"]
 	path = Docs
 	url = https://github.com/FlowCV-org/FlowCV_Documentation.git
+[submodule "FlowCV_SDK/third-party/spdlog"]
+	path = FlowCV_SDK/third-party/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "Docs"]
 	path = Docs
 	url = https://github.com/FlowCV-org/FlowCV_Documentation.git
-[submodule "FlowCV_SDK/third-party/spdlog"]
-	path = FlowCV_SDK/third-party/spdlog
-	url = https://github.com/gabime/spdlog.git

--- a/CMake/FlowCVConfig.cmake
+++ b/CMake/FlowCVConfig.cmake
@@ -1,6 +1,7 @@
 message(STATUS "Adding FlowCV CMake Config")
 
 include_directories(${CMAKE_SOURCE_DIR}/Managers)
+include_directories(${CMAKE_SOURCE_DIR}/Utils)
 include_directories(${CMAKE_SOURCE_DIR}/FlowCV_SDK/include)
 list(APPEND FlowCV_SRC ${CMAKE_SOURCE_DIR}/FlowCV_SDK/src/FlowCV_Types.cpp)
 list(APPEND FlowCV_SRC ${CMAKE_SOURCE_DIR}/FlowCV_SDK/src/FlowCV_Properties.cpp)

--- a/CMake/spdlogSetupConfig.cmake
+++ b/CMake/spdlogSetupConfig.cmake
@@ -1,0 +1,15 @@
+message(STATUS "Configuring spdlog")
+
+# https://github.com/gabime/spdlog/issues/2758
+include(FetchContent)
+
+FetchContent_Declare(
+    spdlog
+    GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
+    GIT_TAG v1.12.0
+)
+FetchContent_MakeAvailable(spdlog)
+
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/_deps/spdlog-src/include")
+
+add_compile_options(-DSPDLOG_COMPILED_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,10 @@ include(${CMAKE_SOURCE_DIR}/CMake/FlowCVConfig.cmake)
 # JSON
 include_directories(${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/nlohmann)
 
-if (BUILD_PLUGINS)
+# log
+include_directories(${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/spdlog/include)
+
+if(BUILD_PLUGINS)
     # FlowCV Plugin Modules
     add_subdirectory(./Plugins/VideoCapture)
     add_subdirectory(./Plugins/VideoWriter)
@@ -35,21 +38,19 @@ if (BUILD_PLUGINS)
     add_subdirectory(./Plugins/SimpleBlobTracker)
     add_subdirectory(./Plugins/DataOutput)
     add_subdirectory(./Plugins/ImageWriter)
-
-
 endif()
 
-if (BUILD_ENGINE)
+if(BUILD_ENGINE)
     # OpenCV DSPatch Standalone Processing Engine
     add_subdirectory(Processing_Engine)
 endif()
 
-if (BUILD_EDITOR)
+if(BUILD_EDITOR)
     # OpenCV DSPatch Node Editor UI
     add_subdirectory(Editor_UI)
 endif()
 
-if (BUILD_EXAMPLES)
+if(BUILD_EXAMPLES)
     # Build Examples
     add_subdirectory(Examples/FlowCV_Dataflow_Test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,10 @@ include(${CMAKE_SOURCE_DIR}/CMake/ImGuiNodeEditorConfig.cmake)
 include(${CMAKE_SOURCE_DIR}/CMake/ImGuiFileDialogConfig.cmake)
 include(${CMAKE_SOURCE_DIR}/CMake/DSPatchConfig.cmake)
 include(${CMAKE_SOURCE_DIR}/CMake/FlowCVConfig.cmake)
+include(${CMAKE_SOURCE_DIR}/CMake/spdlogSetupConfig.cmake)
 
 # JSON
 include_directories(${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/nlohmann)
-
-# log
-include_directories(${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/spdlog/include)
 
 if(BUILD_PLUGINS)
     # FlowCV Plugin Modules

--- a/Editor_UI/CMakeLists.txt
+++ b/Editor_UI/CMakeLists.txt
@@ -2,17 +2,19 @@ project(FlowCV_Editor)
 
 include_directories(${CMAKE_SOURCE_DIR}/Internal_Nodes)
 include_directories(${CMAKE_SOURCE_DIR}/Managers)
+include_directories(${CMAKE_SOURCE_DIR}/Utils)
 include_directories("${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/tclap/include")
 
 file(GLOB_RECURSE INTERNAL_SRC ${CMAKE_SOURCE_DIR}/Internal_Nodes/*.cpp)
 file(GLOB_RECURSE MANAGER_SRC ${CMAKE_SOURCE_DIR}/Managers/*.cpp)
+file(GLOB_RECURSE UTILS_SRC ${CMAKE_SOURCE_DIR}/Utils/*.cpp)
 file(GLOB COMMON_SRC ${CMAKE_SOURCE_DIR}/Editor_UI/Common/*.cpp)
 
-if (WIN32)
+if(WIN32)
     set(APP_ICON_RESOURCE_WINDOWS ${CMAKE_CURRENT_SOURCE_DIR}/Node_Editor/appicon.rc)
 endif()
 
-if (UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE)
     add_link_options(-fno-pie -no-pie -Wl,--disable-new-dtags)
     set(STB_IMAGE_LIB stb_image)
     FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/Node_Editor_Resource)
@@ -20,50 +22,51 @@ if (UNIX AND NOT APPLE)
 endif()
 
 add_executable(${PROJECT_NAME}
-        ${COMMON_SRC}
-        ./Node_Editor/node_editor.cpp
-        ${IMGUI_SRC}
-        ${FlowCV_SRC}
-        ${DSPatch_SRC}
-        ${IMGUI_WRAPPER_SRC}
-        ${IMGUI_NODE_EDITOR_SRC}
-        ${IMGUI_OPENCV_SRC}
-        ${INTERNAL_SRC}
-        ${MANAGER_SRC}
-        ${APP_ICON_RESOURCE_WINDOWS}
-        )
+    ${COMMON_SRC}
+    ./Node_Editor/node_editor.cpp
+    ${IMGUI_SRC}
+    ${FlowCV_SRC}
+    ${DSPatch_SRC}
+    ${IMGUI_WRAPPER_SRC}
+    ${IMGUI_NODE_EDITOR_SRC}
+    ${IMGUI_OPENCV_SRC}
+    ${INTERNAL_SRC}
+    ${MANAGER_SRC}
+    ${UTILS_SRC}
+    ${APP_ICON_RESOURCE_WINDOWS}
+)
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME}
-            ${IMGUI_LIBS}
-            ${OpenCV_LIBS}
-            )
+        ${IMGUI_LIBS}
+        ${OpenCV_LIBS}
+    )
 else()
     target_link_libraries(${PROJECT_NAME}
-            ${IMGUI_LIBS}
-            ${OpenCV_LIBS}
-            ${STB_IMAGE_LIB}
-            pthread
-            )
+        ${IMGUI_LIBS}
+        ${OpenCV_LIBS}
+        ${STB_IMAGE_LIB}
+        pthread
+    )
 endif()
 
 if(WIN32)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    )
 elseif(UNIX AND NOT APPLE)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_RPATH "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+        INSTALL_RPATH "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
+        BUILD_WITH_INSTALL_RPATH ON
+    )
 elseif(APPLE)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_NAME_DIR "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+        INSTALL_NAME_DIR "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
+        BUILD_WITH_INSTALL_NAME_DIR ON
+    )
 endif()

--- a/Editor_UI/CMakeLists.txt
+++ b/Editor_UI/CMakeLists.txt
@@ -40,6 +40,7 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
     )
 else()
     target_link_libraries(${PROJECT_NAME}
@@ -47,6 +48,7 @@ else()
         ${OpenCV_LIBS}
         ${STB_IMAGE_LIB}
         pthread
+        spdlog::spdlog
     )
 endif()
 

--- a/Editor_UI/Common/app_settings.cpp
+++ b/Editor_UI/Common/app_settings.cpp
@@ -4,6 +4,8 @@
 
 #include "app_settings.h"
 
+#include "FlowLogger.hpp"
+
 void ApplicationLoadSettings(AppSettings &settings)
 {
     if (std::filesystem::exists(settings.configPath)) {
@@ -32,7 +34,7 @@ void ApplicationLoadSettings(AppSettings &settings)
                 settings.flowBufferCount = j["buffer_count"].get<int>();
         }
         catch (const std::exception &e) {
-            std::cout << "Error Loading Application Settings" << std::endl;
+            LOG_ERROR("Error Loading Application Settings");
             std::cerr << e.what();
         }
     }

--- a/Editor_UI/Common/app_settings.cpp
+++ b/Editor_UI/Common/app_settings.cpp
@@ -30,6 +30,8 @@ void ApplicationLoadSettings(AppSettings &settings)
                 settings.useVSync = j["use_vsync"].get<bool>();
             if (j.contains("show_fps"))
                 settings.showFPS = j["show_fps"].get<bool>();
+            if (j.contains("log_level"))
+                settings.logLevel = j["log_level"].get<int>();
             if (j.contains("buffer_count"))
                 settings.flowBufferCount = j["buffer_count"].get<int>();
         }
@@ -59,6 +61,9 @@ void ApplicationSaveSettings(const AppSettings &settings)
 
     if (settings.showFPS)
         j["show_fps"] = settings.showFPS;
+
+    if (settings.logLevel)
+        j["log_level"] = settings.logLevel;
 
     if (settings.useVSync)
         j["use_vsync"] = settings.useVSync;

--- a/Editor_UI/Common/app_settings.h
+++ b/Editor_UI/Common/app_settings.h
@@ -20,6 +20,7 @@ struct AppSettings
     bool showFPS;
     bool useVSync;
     int flowBufferCount;
+    int logLevel;
 };
 
 

--- a/Editor_UI/Common/entry.cpp
+++ b/Editor_UI/Common/entry.cpp
@@ -88,7 +88,7 @@ void ApplicationSettingsDialog(AppSettings &settings, bool &windowState)
             sel = ImGui::Selectable(settings.extPluginDir.at(i).c_str(), false);
 
         if (sel) {
-            std::cout << i << std::endl;
+            LOG_INFO("{}",i);
             plugin_path_select = i;
         }
     }
@@ -490,7 +490,7 @@ int main(int argc, char *argv[])
             bool res = Application_SetState(flowMan, state);
             appGlobals->showLoadDialog = false;
             if (!res) {
-                std::cout << "Error!" << std::endl;
+                LOG_ERROR("Error!");
                 errorMsg = "There Were Errors Loading FLow";
                 ImGui::OpenPopup("Error Dialog");
             }

--- a/Editor_UI/Common/entry.cpp
+++ b/Editor_UI/Common/entry.cpp
@@ -1,3 +1,4 @@
+#include "imgui.h"
 #include <application.h>
 #include <cstdio>
 #include <iomanip>
@@ -75,6 +76,11 @@ void ApplicationSettingsDialog(AppSettings &settings, bool &windowState)
             glfwSwapInterval(0);
     }
     ImGui::Checkbox("Show FPS", &settings.showFPS);
+    ImGui::Separator();
+    ImGui::Combo("Log Level",&settings.logLevel,"debug\0info\0warnning\0off\0\0");
+    if (FlowCV::FlowLogger::getLevel() != settings.logLevel) {
+        FlowCV::FlowLogger::setLevel((FlowCV::FlowLogger::Level)settings.logLevel);
+    }
     ImGui::Separator();
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 5.0f);
     ImGui::BeginChild("ChildR", ImVec2(-1, 260), true, ImGuiWindowFlags_None);
@@ -171,6 +177,7 @@ int main(int argc, char *argv[])
     appSettings.flowBufferCount = 1;
     appSettings.showFPS = false;
     appSettings.useVSync = false;
+    appSettings.logLevel = FlowCV::FlowLogger::getLevel();
 
     CmdLine cmd("FlowCV Node Editor", ' ', FLOWCV_EDITOR_VERSION_STR);
     ValueArg<std::string> cfg_file_arg("c", "cfg", "Default Config File Override", false, "", "string");

--- a/Editor_UI/Common/entry.cpp
+++ b/Editor_UI/Common/entry.cpp
@@ -11,6 +11,8 @@
 #include <mach-o/dyld.h>
 #endif
 
+#include "FlowLogger.hpp"
+
 using namespace TCLAP;
 
 ApplicationGlobals* GetApplicationGlobals()
@@ -155,6 +157,8 @@ std::string SaveFlowFile(ImGuiWrapper &imgui, FlowCV::FlowCV_Manager &flowMan, s
 
 int main(int argc, char *argv[])
 {
+    LOGGER_INIT;
+    
     FlowCV::FlowCV_Manager flowMan;
     ImGuiWrapper imgui;
     std::string pluginDir;

--- a/Editor_UI/Node_Editor/node_editor.cpp
+++ b/Editor_UI/Node_Editor/node_editor.cpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <chrono>
 
+#include "FlowLogger.hpp"
+
 #define IN_OFFSET 99
 #define OUT_OFFSET 199
 
@@ -247,7 +249,7 @@ void PasteNodes(FlowCV::FlowCV_Manager &flowMan)
         flowMan.StartAutoTick();
     }
     catch (const std::exception &e) {
-        std::cout << e.what() << std::endl;
+        LOG_ERROR("{}", e.what());
     }
 }
 

--- a/FlowCV_SDK/CMake/FlowCVConfig.cmake
+++ b/FlowCV_SDK/CMake/FlowCVConfig.cmake
@@ -1,4 +1,4 @@
-#FlowCV Config
+# FlowCV Config
 message(STATUS "Adding FlowCV CMake Config")
 
 # FlowCV Managers
@@ -9,4 +9,4 @@ list(APPEND FlowCV_SRC ${FLOWCV_PROJ_DIR}/src/FlowCV_Properties.cpp)
 # Third Party
 include_directories(${FLOWCV_PROJ_DIR}/third-party)
 include_directories(${FLOWCV_PROJ_DIR}/third-party/nlohmann)
-
+include_directories(${FLOWCV_PROJ_DIR}/third-party/spdlog/include)

--- a/FlowCV_SDK/CMake/spdlogSetupConfig.cmake
+++ b/FlowCV_SDK/CMake/spdlogSetupConfig.cmake
@@ -1,0 +1,15 @@
+message(STATUS "Configuring spdlog")
+
+# https://github.com/gabime/spdlog/issues/2758
+include(FetchContent)
+
+FetchContent_Declare(
+    spdlog
+    GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
+    GIT_TAG v1.12.0
+)
+FetchContent_MakeAvailable(spdlog)
+
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/_deps/spdlog-src/include")
+
+add_compile_options(-DSPDLOG_COMPILED_LIB)

--- a/FlowCV_SDK/FlowCVConfig.cmake
+++ b/FlowCV_SDK/FlowCVConfig.cmake
@@ -1,11 +1,11 @@
 # ======================================================
-#  Version variables:
+# Version variables:
 # ======================================================
 set(FLOWCV_VERSION 1.1.0)
-set(FLOWCV_VERSION_MAJOR  1)
-set(FLOWCV_VERSION_MINOR  1)
-set(FLOWCV_VERSION_PATCH  0)
-set(FLOWCV_VERSION_TWEAK  0)
+set(FLOWCV_VERSION_MAJOR 1)
+set(FLOWCV_VERSION_MINOR 1)
+set(FLOWCV_VERSION_PATCH 0)
+set(FLOWCV_VERSION_TWEAK 0)
 set(FLOWCV_VERSION_STATUS "")
 
 set(FLOWCV_PROJ_DIR ${CMAKE_CURRENT_LIST_DIR})
@@ -16,3 +16,4 @@ include(${FLOWCV_PROJ_DIR}/CMake/ImGuiConfig.cmake)
 include(${FLOWCV_PROJ_DIR}/CMake/FlowCVConfig.cmake)
 include(${FLOWCV_PROJ_DIR}/CMake/DSPatchConfig.cmake)
 include(${FLOWCV_PROJ_DIR}/CMake/OpenCvConfig.cmake)
+include(${FLOWCV_PROJ_DIR}/CMake/spdlogSetupConfig.cmake)

--- a/FlowCV_SDK/include/FlowCV_Types.hpp
+++ b/FlowCV_SDK/include/FlowCV_Types.hpp
@@ -5,6 +5,9 @@
 #ifndef FLOWCV_TYPES_HPP_
 #define FLOWCV_TYPES_HPP_
 
+#include <map>
+#include <string>
+
 namespace FlowCV
 {
 

--- a/Managers/FlowCV_Manager.cpp
+++ b/Managers/FlowCV_Manager.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "FlowCV_Manager.hpp"
+#include "FlowLogger.hpp"
 
 namespace FlowCV
 {
@@ -219,7 +220,7 @@ bool FlowCV_Manager::SetState(nlohmann::json &state)
                     ni.node_ptr->SetInstanceCount(inst_num);
                     ni.node_ptr->SetEnabled(enabled);
                     CheckInstCountValue(ni);
-                    // std::cout << "Adding Node Instance (Plugin): " << name << ", " << id << std::endl;
+                    LOG_DEBUG("Adding Node Instance (Plugin): {}, {}", name, id);
                     if (node.contains("params")) {
                         ni.node_ptr->SetState(node["params"].dump());
                     }
@@ -232,13 +233,13 @@ bool FlowCV_Manager::SetState(nlohmann::json &state)
                         ni.node_ptr->SetInstanceCount(inst_num);
                         ni.node_ptr->SetEnabled(enabled);
                         CheckInstCountValue(ni);
-                        // std::cout << "Adding Node Instance (Internal): " << name << ", " << id << std::endl;
+                        LOG_DEBUG("Adding Node Instance (Plugin): {}, {}", name, id);
                         if (node.contains("params")) {
                             ni.node_ptr->SetState(node["params"].dump());
                         }
                     }
                     else {
-                        // std::cout << "Node Name: " << name.c_str() << " Not Found" << std::endl;
+                        LOG_DEBUG("Node Name: {} Not Found", name);
                         res = false;
                     }
                 }

--- a/Managers/Plugin_Manager.cpp
+++ b/Managers/Plugin_Manager.cpp
@@ -6,6 +6,8 @@
 #include <filesystem>
 #include <algorithm>
 
+#include "FlowLogger.hpp"
+
 namespace FlowCV
 {
 PluginManager::~PluginManager()
@@ -33,7 +35,7 @@ void PluginManager::ScanDirForPlugins(const char *dir_path, bool recursive)
             int extLen = ext.size();
             std::string ending = filename.substr(filename.size() - extLen, extLen);
             if (ending == ext) {
-                std::cout << entry.path() << std::endl;
+                LOG_INFO("{}", entry.path().string());
                 PluginInfo pi;
                 pi.plugin_handle = new DSPatch::Plugin(filename);
                 if (pi.plugin_handle->IsLoaded()) {
@@ -58,7 +60,7 @@ void PluginManager::ScanDirForPlugins(const char *dir_path, bool recursive)
 void PluginManager::LoadPlugins(const char *plugin_path, bool recursive)
 {
     plugin_path_ = plugin_path;
-    std::cout << "Looking for Plugins in: " << plugin_path << std::endl;
+    LOG_INFO("Looking for Plugins in: {}", plugin_path);
     ScanDirForPlugins(plugin_path_.c_str());
 }
 

--- a/Plugins/DataOutput/CMakeLists.txt
+++ b/Plugins/DataOutput/CMakeLists.txt
@@ -4,16 +4,18 @@ include(${CMAKE_SOURCE_DIR}/CMake/asio2SetupConfig.cmake)
 
 LIST(APPEND SER_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/serial_enumerator.cpp)
 
-if (WIN32)
+if(WIN32)
         include_directories(${CMAKE_CURRENT_SOURCE_DIR}/win)
         LIST(APPEND SER_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/win/List_Serial_Ports_Win.cpp)
         LIST(APPEND SER_ENUM_LIB setupapi)
-endif ()
-if (UNIX AND NOT APPLE)
+endif()
+
+if(UNIX AND NOT APPLE)
         include_directories(${CMAKE_CURRENT_SOURCE_DIR}/linux)
         LIST(APPEND SER_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/linux/List_Serial_Ports_Linux.cpp)
 endif()
-if (APPLE)
+
+if(APPLE)
         find_library(IOKIT_LIBRARY IOKit)
         find_library(FOUNDATION_LIBRARY Foundation)
         set(MAC_SER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/macos/serial)
@@ -24,7 +26,7 @@ if (APPLE)
                 ${MAC_SER_DIR}/src/serial.cc
                 ${MAC_SER_DIR}/include/serial/serial.h
                 ${MAC_SER_DIR}/include/serial/v8stdint.h
-                )
+        )
         list(APPEND serial_SRCS ${MAC_SER_DIR}/src/impl/unix.cc)
         list(APPEND serial_SRCS ${MAC_SER_DIR}/src/impl/list_ports/list_ports_osx.cc)
 endif()
@@ -47,29 +49,31 @@ target_link_libraries(
         UdpSend
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
+
 if(WIN32)
-set_target_properties(UdpSend
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(UdpSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(UdpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(UdpSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(UdpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(UdpSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()
 
 # TCP Send
@@ -86,29 +90,31 @@ target_link_libraries(
         TcpSend
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
+
 if(WIN32)
-set_target_properties(TcpSend
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(TcpSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(TcpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(TcpSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(TcpSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(TcpSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()
 
 # Serial Send
@@ -123,7 +129,8 @@ add_library(
         ${SER_ENUM_SRC}
         ${serial_SRCS}
 )
-if (APPLE)
+
+if(APPLE)
         target_link_libraries(
                 SerialSend
                 ${IMGUI_LIBS}
@@ -131,37 +138,40 @@ if (APPLE)
                 ${SER_ENUM_LIB}
                 ${FOUNDATION_LIBRARY}
                 ${IOKIT_LIBRARY}
+                spdlog::spdlog
         )
 else()
-target_link_libraries(
-        SerialSend
-        ${IMGUI_LIBS}
-        ${OpenCV_LIBS}
-        ${SER_ENUM_LIB}
-)
+        target_link_libraries(
+                SerialSend
+                ${IMGUI_LIBS}
+                ${OpenCV_LIBS}
+                ${SER_ENUM_LIB}
+                spdlog::spdlog
+        )
 endif()
+
 if(WIN32)
-set_target_properties(SerialSend
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(SerialSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(SerialSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(SerialSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(SerialSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(SerialSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()
 
 # OSC Send
@@ -179,29 +189,31 @@ target_link_libraries(
         OscSend
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
+
 if(WIN32)
-set_target_properties(OscSend
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(OscSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(OscSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(OscSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(OscSend
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(OscSend
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()
 
 # CSV File
@@ -219,26 +231,27 @@ target_link_libraries(
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
 )
+
 if(WIN32)
-set_target_properties(CsvFile
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(CsvFile
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(CsvFile
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(CsvFile
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(CsvFile
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(CsvFile
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/ImageLoader/CMakeLists.txt
+++ b/Plugins/ImageLoader/CMakeLists.txt
@@ -14,28 +14,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/ImageWriter/CMakeLists.txt
+++ b/Plugins/ImageWriter/CMakeLists.txt
@@ -14,28 +14,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/ImageWriter/image_writer.cpp
+++ b/Plugins/ImageWriter/image_writer.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "image_writer.hpp"
+#include "FlowLogger.hpp"
 
 using namespace DSPatch;
 using namespace DSPatchables;
@@ -95,9 +96,11 @@ void ImageWriter::UpdateGui(void *context, int interface)
 
         if (file_dialog_.showFileDialog(CreateControlString("Save Image", GetInstanceName()), imgui_addons::ImGuiFileBrowser::DialogMode::SAVE,
                 ImVec2(700, 310), "*.*", &show_file_dialog_)) {
-            std::cout << file_dialog_.selected_path << std::endl;
-            std::cout << file_dialog_.selected_fn << std::endl;
-            std::cout << file_dialog_.ext << std::endl;
+
+            LOG_INFO("{}", file_dialog_.selected_path);
+            LOG_INFO("{}", file_dialog_.selected_fn);
+            LOG_INFO("{}", file_dialog_.ext);
+
             image_file_ = file_dialog_.selected_path;
             show_file_dialog_ = false;
         }

--- a/Plugins/ImageWriter/image_writer.hpp
+++ b/Plugins/ImageWriter/image_writer.hpp
@@ -11,6 +11,8 @@
 #include "json.hpp"
 #include <ImGuiFileBrowser.h>
 
+#include "FlowLogger.hpp"
+
 namespace DSPatch::DSPatchables
 {
 namespace internal

--- a/Plugins/ShapeColorizer/CMakeLists.txt
+++ b/Plugins/ShapeColorizer/CMakeLists.txt
@@ -14,28 +14,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/ShapeCounter/CMakeLists.txt
+++ b/Plugins/ShapeCounter/CMakeLists.txt
@@ -14,28 +14,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/SimpleBlobTracker/CMakeLists.txt
+++ b/Plugins/SimpleBlobTracker/CMakeLists.txt
@@ -14,28 +14,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/VideoCapture/CMakeLists.txt
+++ b/Plugins/VideoCapture/CMakeLists.txt
@@ -2,15 +2,17 @@ project(VideoCapture)
 
 LIST(APPEND CAM_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/camera_enumerator.cpp)
 
-if (WIN32)
+if(WIN32)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/win)
     LIST(APPEND CAM_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/win/Camera_MSMF.cpp)
-endif ()
-if (UNIX AND NOT APPLE)
+endif()
+
+if(UNIX AND NOT APPLE)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/linux)
     LIST(APPEND CAM_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/linux/Camera_V4L.cpp)
 endif()
-if (APPLE)
+
+if(APPLE)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/macos)
     LIST(APPEND CAM_ENUM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/macos/Camera_MacOS.cpp)
     find_library(IOKIT_LIBRARY IOKit)
@@ -18,44 +20,44 @@ if (APPLE)
 endif()
 
 add_library(
-        ${PROJECT_NAME} SHARED
-        video_capture.cpp
-        ${IMGUI_SRC}
-        ${DSPatch_SRC}
-        ${IMGUI_WRAPPER_SRC}
-        ${IMGUI_OPENCV_SRC}
-        ${FlowCV_SRC}
-        ${CAM_ENUM_SRC}
-        )
+    ${PROJECT_NAME} SHARED
+    video_capture.cpp
+    ${IMGUI_SRC}
+    ${DSPatch_SRC}
+    ${IMGUI_WRAPPER_SRC}
+    ${IMGUI_OPENCV_SRC}
+    ${FlowCV_SRC}
+    ${CAM_ENUM_SRC}
+)
 
 target_link_libraries(
-        ${PROJECT_NAME}
-        ${IMGUI_LIBS}
-        ${OpenCV_LIBS}
-        ${SYS_LIBS}
+    ${PROJECT_NAME}
+    ${IMGUI_LIBS}
+    ${OpenCV_LIBS}
+    ${SYS_LIBS}
+    spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
+    set_target_properties(${PROJECT_NAME}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
         SUFFIX ".fp"
-        )
+    )
 elseif(UNIX AND NOT APPLE)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+        SUFFIX ".fp"
+        INSTALL_RPATH "${ORIGIN}"
+        BUILD_WITH_INSTALL_RPATH ON
+    )
 elseif(APPLE)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+        SUFFIX ".fp"
+        INSTALL_NAME_DIR "${ORIGIN}"
+        BUILD_WITH_INSTALL_NAME_DIR ON
+    )
 endif()
-

--- a/Plugins/VideoLoader/CMakeLists.txt
+++ b/Plugins/VideoLoader/CMakeLists.txt
@@ -15,28 +15,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Plugins/VideoWriter/CMakeLists.txt
+++ b/Plugins/VideoWriter/CMakeLists.txt
@@ -14,28 +14,29 @@ target_link_libraries(
         ${PROJECT_NAME}
         ${IMGUI_LIBS}
         ${OpenCV_LIBS}
+        spdlog::spdlog
 )
 
 if(WIN32)
-set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-        SUFFIX ".fp"
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
         )
 elseif(UNIX AND NOT APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_RPATH "${ORIGIN}"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_RPATH "${ORIGIN}"
+                BUILD_WITH_INSTALL_RPATH ON
+        )
 elseif(APPLE)
-    set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
-            SUFFIX ".fp"
-            INSTALL_NAME_DIR "${ORIGIN}"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        set_target_properties(${PROJECT_NAME}
+                PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Plugins"
+                SUFFIX ".fp"
+                INSTALL_NAME_DIR "${ORIGIN}"
+                BUILD_WITH_INSTALL_NAME_DIR ON
+        )
 endif()

--- a/Processing_Engine/CMakeLists.txt
+++ b/Processing_Engine/CMakeLists.txt
@@ -8,53 +8,55 @@ include_directories("${CMAKE_SOURCE_DIR}/FlowCV_SDK/third-party/tclap/include")
 file(GLOB_RECURSE INTERNAL_SRC ${CMAKE_SOURCE_DIR}/Internal_Nodes/*.cpp)
 file(GLOB_RECURSE MANAGER_SRC ${CMAKE_SOURCE_DIR}/Managers/*.cpp)
 
-if (UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE)
     add_link_options(-fno-pie -no-pie -Wl,--disable-new-dtags)
     set(STB_IMAGE_LIB stb_image)
 endif()
 
 add_executable(${PROJECT_NAME} headless_process_engine.cpp
-        ${CMAKE_SOURCE_DIR}/Editor_UI/Common/app_settings.cpp
-        ${IMGUI_SRC}
-        ${FlowCV_SRC}
-        ${DSPatch_SRC}
-        ${IMGUI_WRAPPER_SRC}
-        ${IMGUI_OPENCV_SRC}
-        ${INTERNAL_SRC}
-        ${MANAGER_SRC}
-        )
+    ${CMAKE_SOURCE_DIR}/Editor_UI/Common/app_settings.cpp
+    ${IMGUI_SRC}
+    ${FlowCV_SRC}
+    ${DSPatch_SRC}
+    ${IMGUI_WRAPPER_SRC}
+    ${IMGUI_OPENCV_SRC}
+    ${INTERNAL_SRC}
+    ${MANAGER_SRC}
+)
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME}
-            ${IMGUI_LIBS}
-            ${OpenCV_LIBS}
-            )
+        ${IMGUI_LIBS}
+        ${OpenCV_LIBS}
+        spdlog::spdlog
+    )
 else()
     target_link_libraries(${PROJECT_NAME}
-            ${IMGUI_LIBS}
-            ${OpenCV_LIBS}
-            ${STB_IMAGE_LIB}
-            pthread
-            )
+        ${IMGUI_LIBS}
+        ${OpenCV_LIBS}
+        ${STB_IMAGE_LIB}
+        pthread
+        spdlog::spdlog
+    )
 endif()
 
 if(WIN32)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    )
 elseif(UNIX AND NOT APPLE)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_RPATH "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_RPATH ON
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+        INSTALL_RPATH "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
+        BUILD_WITH_INSTALL_RPATH ON
+    )
 elseif(APPLE)
     set_target_properties(${PROJECT_NAME}
-            PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-            INSTALL_NAME_DIR "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
-            BUILD_WITH_INSTALL_NAME_DIR ON
-            )
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+        INSTALL_NAME_DIR "${ORIGIN};./;./Plugins/OpenVino;./Plugins/RealSense;./Plugins/NDI;./Plugins/OakCamera"
+        BUILD_WITH_INSTALL_NAME_DIR ON
+    )
 endif()

--- a/Processing_Engine/headless_process_engine.cpp
+++ b/Processing_Engine/headless_process_engine.cpp
@@ -19,6 +19,8 @@
 #include <mach-o/dyld.h>
 #endif
 
+#include "FlowLogger.hpp"
+
 #define APP_VERSION "0.1.3"
 
 using namespace TCLAP;
@@ -58,9 +60,7 @@ int main(int argc, char *argv[])
     cmd.add(cfg_file_arg);
     cmd.parse(argc, argv);
 
-    cout << endl;
-    cout << "FlowCV Processing Engine - v" << APP_VERSION << endl;
-    cout << endl;
+    LOG_INFO("\nFlowCV Processing Engine - v{}\n", APP_VERSION);
 
     FlowCV::FlowCV_Manager flowMan;
 
@@ -133,19 +133,19 @@ int main(int argc, char *argv[])
                 flowMan.plugin_manager_->LoadPlugins(path.c_str(), false);
         }
     }
-    cout << flowMan.plugin_manager_->PluginCount() << " Plugin(s) Loaded" << endl;
+    LOG_INFO("{} Plugin(s) Loaded", flowMan.plugin_manager_->PluginCount());
 
-    cout << "Loading Flow File: " << flow_file_arg.getValue().c_str() << endl;
+    LOG_INFO("Loading Flow File: {}", flow_file_arg.getValue());
     if (!flowMan.LoadState(flow_file_arg.getValue().c_str())) {
-        cout << "Error Loading Flow File" << endl;
+        LOG_ERROR("Error Loading Flow File");
         return EXIT_FAILURE;
     }
-    cout << "Flow State Loaded, " << flowMan.GetNodeCount() << " Nodes Loaded and Configured" << endl;
+    LOG_INFO("Flow State Loaded, {} Nodes Loaded and Configured", flowMan.GetNodeCount());
 
     // Init Signal Handling (Cntrl-C, Cntrl-X to clean exit)
     Init_Signal();
 
-    cout << "Flow Processing Started" << endl;
+    LOG_INFO("Flow Processing Started");
     // Start Multi-Threaded Flow Processing in Background
     flowMan.StartAutoTick();
 
@@ -157,8 +157,7 @@ int main(int argc, char *argv[])
     // Stop Flow Before Going Out of Scope and Cleanup
     flowMan.StopAutoTick();
 
-    cout << "Flow Processing Stopped" << endl;
-    cout << "Exiting" << endl;
+    LOG_INFO("Flow Processing Stopped\nExiting");
 
     return EXIT_SUCCESS;
 }

--- a/Utils/FlowLogger.cpp
+++ b/Utils/FlowLogger.cpp
@@ -6,6 +6,9 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+namespace FlowCV
+{
+
 FlowLogger::FlowLogger()
 {
     spdlog::init_thread_pool(8192, 1);
@@ -43,15 +46,19 @@ void FlowLogger::setLevel(Level l)
     switch (l) {
         case Level::debug:
             level = spdlog::level::level_enum::debug;
+            LOG_INFO("set log level to debug");
             break;
         case Level::info:
             level = spdlog::level::level_enum::info;
+            LOG_INFO("set log level to info");
             break;
         case Level::warn:
             level = spdlog::level::level_enum::warn;
+            LOG_INFO("set log level to warn");
             break;
         case Level::off:
             level = spdlog::level::level_enum::off;
+            LOG_INFO("set log level to off");
             break;
 
         default:
@@ -59,3 +66,5 @@ void FlowLogger::setLevel(Level l)
     }
     spdlog::set_level(level);
 }
+
+}  // namespace FlowCV

--- a/Utils/FlowLogger.cpp
+++ b/Utils/FlowLogger.cpp
@@ -1,0 +1,61 @@
+
+#include "FlowLogger.hpp"
+
+#include <spdlog/async.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+FlowLogger::FlowLogger()
+{
+    spdlog::init_thread_pool(8192, 1);
+    auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+
+    auto daily_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>("logs/log.log", 2, 30);
+
+    std::vector<spdlog::sink_ptr> sinks{console_sink, daily_sink};
+    auto logger = std::make_shared<spdlog::async_logger>("flow", sinks.begin(), sinks.end(), spdlog::thread_pool(), spdlog::async_overflow_policy::block);
+
+    spdlog::register_logger(logger);
+    spdlog::set_default_logger(logger);
+}
+
+FlowLogger::Level FlowLogger::getLevel()
+{
+    switch (spdlog::get_level()) {
+        case spdlog::level::level_enum::debug:
+            return Level::debug;
+        case spdlog::level::level_enum::info:
+            return Level::info;
+        case spdlog::level::level_enum::warn:
+            return Level::warn;
+        case spdlog::level::level_enum::off:
+            return Level::off;
+        default:
+            break;
+    }
+    return Level::debug;
+}
+
+void FlowLogger::setLevel(Level l)
+{
+    auto level = spdlog::level::level_enum::debug;
+    switch (l) {
+        case Level::debug:
+            level = spdlog::level::level_enum::debug;
+            break;
+        case Level::info:
+            level = spdlog::level::level_enum::info;
+            break;
+        case Level::warn:
+            level = spdlog::level::level_enum::warn;
+            break;
+        case Level::off:
+            level = spdlog::level::level_enum::off;
+            break;
+
+        default:
+            break;
+    }
+    spdlog::set_level(level);
+}

--- a/Utils/FlowLogger.hpp
+++ b/Utils/FlowLogger.hpp
@@ -4,9 +4,12 @@
 
 #include <string>
 
+namespace FlowCV
+{
+
 #ifdef SPDLOG_H
 #ifndef LOGGER_INIT
-#define LOGGER_INIT FlowLogger();
+#define LOGGER_INIT FlowCV::FlowLogger();
 #endif
 #ifndef LOG_DEBUG
 #define LOG_DEBUG(...) SPDLOG_DEBUG(__VA_ARGS__)
@@ -54,3 +57,5 @@ class FlowLogger
     static Level getLevel();
     static void setLevel(Level l);
 };
+
+}  // namespace FlowCV

--- a/Utils/FlowLogger.hpp
+++ b/Utils/FlowLogger.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+#include <string>
+
+#ifdef SPDLOG_H
+#ifndef LOGGER_INIT
+#define LOGGER_INIT FlowLogger();
+#endif
+#ifndef LOG_DEBUG
+#define LOG_DEBUG(...) SPDLOG_DEBUG(__VA_ARGS__)
+#endif
+#ifndef LOG_INFO
+#define LOG_INFO(...) SPDLOG_INFO(__VA_ARGS__)
+#endif
+#ifndef LOG_WARN
+#define LOG_WARN(...) SPDLOG_WARN(__VA_ARGS__)
+#endif
+#else
+#ifndef LOGGER_INIT
+#define LOGGER_INIT (void)0
+#endif
+#ifndef LOG_DEBUG
+#define LOG_DEBUG(...) (void)0;
+#endif
+#ifndef LOG_INFO
+#define LOG_INFO(...) (void)0
+#endif
+#ifndef LOG_WARN
+#define LOG_WARN(...) (void)0
+#endif
+#endif
+
+class FlowLogger
+{
+  public:
+    enum Level : int
+    {
+        debug = 0,
+        info,
+        warn,
+        off
+    };
+
+    FlowLogger();
+
+    static Level getLevel();
+    static void setLevel(Level l);
+};

--- a/Utils/FlowLogger.hpp
+++ b/Utils/FlowLogger.hpp
@@ -17,18 +17,24 @@
 #ifndef LOG_WARN
 #define LOG_WARN(...) SPDLOG_WARN(__VA_ARGS__)
 #endif
+#ifndef LOG_ERROR
+#define LOG_ERROR(...) SPDLOG_ERROR(__VA_ARGS__)
+#endif
 #else
 #ifndef LOGGER_INIT
 #define LOGGER_INIT (void)0
 #endif
 #ifndef LOG_DEBUG
-#define LOG_DEBUG(...) (void)0;
+#define LOG_DEBUG(...) (void)0
 #endif
 #ifndef LOG_INFO
 #define LOG_INFO(...) (void)0
 #endif
 #ifndef LOG_WARN
 #define LOG_WARN(...) (void)0
+#endif
+#ifndef LOG_ERROR
+#define LOG_ERROR(...) (void)0
 #endif
 #endif
 


### PR DESCRIPTION
header-only C++ logging library -- [spdlog](https://github.com/gabime/spdlog.git)

features:
- You can set the log level in the ui，and add to cfg file
- Log files are saved to the logs folder by date, with the suffix `.log`
- Related files introduced in the plug-in can also display and save logs to log files

I also have an idea, can let the plug-in log without the need to introduce 'spdlog' can also be displayed and saved? The initial idea is to implement a log transfer function in EXPORT_PLUGIN, where the plug-in manager receives the plug-in log information. Then let the FlowCV main program display and save the plug-in log.